### PR TITLE
Allow app to run on Spring Boot 1.5.7.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,22 +2,26 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<!--<version>1.5.7.RELEASE</version>-->
-		<version>2.6.8</version>
+		<version>1.5.7.RELEASE</version>
+		<!-- <version>2.6.8</version> -->
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
+
 	<groupId>org.skt</groupId>
 	<artifactId>skt-products-ms</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>skt-products-ms</name>
 	<description>Microservice for SKT Practice Assignment</description>
+
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-cloud.version>2021.0.3</spring-cloud.version>
 	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -35,11 +39,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<!--
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
-			<version>1.4.7.RELEASE</version>
 		</dependency>
+		-->
 
 		<dependency>
 			<groupId>com.h2database</groupId>
@@ -62,14 +67,9 @@
 			<scope>test</scope>
 		</dependency>-->
 		<!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-maven-plugin -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-maven-plugin</artifactId>
-			<version>1.5.0.RELEASE</version>
-		</dependency>
-
-
 	</dependencies>
+
+	<!--
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -81,6 +81,7 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+	-->
 
 	<build>
 		<plugins>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-spring.config.import=optional:configserver:
+# spring.config.import=optional:configserver:

--- a/src/test/java/org/skt/microservice/SktMsApplicationTests.java
+++ b/src/test/java/org/skt/microservice/SktMsApplicationTests.java
@@ -1,13 +1,13 @@
 package org.skt.microservice;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class SktMsApplicationTests {
 
 	@Test
-	void contextLoads() {
+	public void contextLoads() {
 	}
 
 }


### PR DESCRIPTION
I was having issues with Spring Cloud config, but after I commented out that part in the pom.xml, the app can now be started both from the command line (`mvn clean install -DskipTests && mvn spring-boot:run`) and also by clicking the green arrow in the IDE.

After the app starts, the endpoint can be tested with: `curl http://localhost:8080/hello/all`